### PR TITLE
Adds experimental feature to delete pods

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/.gitignore
+++ b/vertical-pod-autoscaler/pkg/updater/.gitignore
@@ -5,3 +5,5 @@ updater-arm64
 updater-arm
 updater-ppc64le
 updater-s390x
+
+.envrc

--- a/vertical-pod-autoscaler/pkg/updater/README.md
+++ b/vertical-pod-autoscaler/pkg/updater/README.md
@@ -26,6 +26,9 @@ Threshold for evicting pods is specified by recommended min/max values from VPA 
 Priority of evictions within a set of replicated pods is proportional to sum of percentages of changes in resources
 (i.e. pod with 15% memory increase 15% cpu decrease recommended will be evicted
 before pod with 20% memory increase and no change in cpu).
+* Deleting pods if the eviction fails and if the corresponding feature flag (`--experimental-deletion`) is enabled.
+Deletion is guarded by a treshold (`--experimental-deletion-threshold`) of how many restarts are required. The pod
+needs to be in `CrashLoopBackOff` and the LastTerminationReason needs to be `OOMKilled`.
 
 # Missing parts
 * Recommendation API for fetching data from Vertical Pod Autoscaler Recommender.

--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
@@ -45,6 +45,9 @@ type PodsEvictionRestriction interface {
 	// Evict sends eviction instruction to the api client.
 	// Returns error if pod cannot be evicted or if client returned error.
 	Evict(pod *apiv1.Pod, eventRecorder record.EventRecorder) error
+	// EvictViaDelete sends deletion instruction to the api client.
+	// Returns error if pod cannot be deleted or if client returned error.
+	EvictViaDelete(pod *apiv1.Pod, eventRecorder record.EventRecorder, deletionThreshold int32) error
 	// CanEvict checks if pod can be safely evicted
 	CanEvict(pod *apiv1.Pod) bool
 }
@@ -143,6 +146,63 @@ func (e *podsEvictionRestrictionImpl) Evict(podToEvict *apiv1.Pod, eventRecorder
 	}
 	eventRecorder.Event(podToEvict, apiv1.EventTypeNormal, "EvictedByVPA",
 		"Pod was evicted by VPA Updater to apply resource recommendation.")
+
+	if podToEvict.Status.Phase != apiv1.PodPending {
+		singleGroupStats, present := e.creatorToSingleGroupStatsMap[cr]
+		if !present {
+			return fmt.Errorf("Internal error - cannot find stats for replication group %v", cr)
+		}
+		singleGroupStats.evicted = singleGroupStats.evicted + 1
+		e.creatorToSingleGroupStatsMap[cr] = singleGroupStats
+	}
+
+	return nil
+}
+
+// canDelete checks if the container has been restarted more than the threshold, and if it has been terminated
+// due to OOMKilled and is in CrashLoopBackOff state.
+func (e *podsEvictionRestrictionImpl) canDelete(containerStatus apiv1.ContainerStatus, deletionThreshold int32) bool {
+	return containerStatus.RestartCount > deletionThreshold &&
+		containerStatus.LastTerminationState.Terminated != nil &&
+		containerStatus.LastTerminationState.Terminated.Reason == "OOMKilled" &&
+		containerStatus.State.Waiting != nil &&
+		containerStatus.State.Waiting.Reason == "CrashLoopBackOff"
+}
+
+// EvictViaDelete sends deletion instruction to api client. Returns error if pod cannot be deleted or if client returned error
+// Does not check if pod was actually deleted after termination grace period.
+func (e *podsEvictionRestrictionImpl) EvictViaDelete(podToEvict *apiv1.Pod, eventRecorder record.EventRecorder, deletionThreshold int32) error {
+	cr, present := e.podToReplicaCreatorMap[getPodID(podToEvict)]
+	if !present {
+		return fmt.Errorf("pod not suitable for eviction %v : not in replicated pods map", podToEvict.Name)
+	}
+
+	if !e.CanEvict(podToEvict) {
+		return fmt.Errorf("cannot evict pod %v : eviction budget exceeded", podToEvict.Name)
+	}
+
+	deleted := false
+	// Try to delete the Pod if it's CrashLooping because of OOM.
+	// The Pod is dead anyway so there is no reason to respect any potential PDBs.
+	for _, containerStatus := range podToEvict.Status.ContainerStatuses {
+		if e.canDelete(containerStatus, deletionThreshold) {
+
+			err := e.client.CoreV1().Pods(podToEvict.Namespace).Delete(context.TODO(), podToEvict.Name, metav1.DeleteOptions{})
+			if err != nil {
+				klog.Errorf("failed to delete pod %s/%s, after failed eviction, error: %v", podToEvict.Namespace, podToEvict.Name, err)
+				return err
+			}
+
+			deleted = true
+			eventRecorder.Event(podToEvict, apiv1.EventTypeNormal, "DeletedByVPA",
+				"Pod was deleted by VPA Updater to apply resource recommendation.")
+			break
+		}
+	}
+
+	if !deleted {
+		return fmt.Errorf("cannot delete pod %v : no container matches deletion conditions", podToEvict.Name)
+	}
 
 	if podToEvict.Status.Phase != apiv1.PodPending {
 		singleGroupStats, present := e.creatorToSingleGroupStatsMap[cr]

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -65,6 +65,9 @@ var (
 
 	namespace          = os.Getenv("NAMESPACE")
 	vpaObjectNamespace = flag.String("vpa-object-namespace", apiv1.NamespaceAll, "Namespace to search for VPA objects. Empty means all namespaces will be used.")
+
+	experimentalDeletion          = flag.Bool("experimental-deletion", false, "Enables the experimental feature of deleting a pod when eviction is not possible for whatever reason.")
+	experimentalDeletionThreshold = flag.Int("experimental-deletion-threshold", 3, "The threshold of how many restarts are required to attempt deletion.")
 )
 
 const defaultResyncPeriod time.Duration = 10 * time.Minute
@@ -108,6 +111,8 @@ func main() {
 		targetSelectorFetcher,
 		priority.NewProcessor(),
 		*vpaObjectNamespace,
+		*experimentalDeletion,
+		*experimentalDeletionThreshold,
 	)
 	if err != nil {
 		klog.Fatalf("Failed to create updater: %v", err)

--- a/vertical-pod-autoscaler/pkg/utils/test/test_pod.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_pod.go
@@ -29,6 +29,7 @@ type PodBuilder interface {
 	WithLabels(labels map[string]string) PodBuilder
 	WithAnnotations(annotations map[string]string) PodBuilder
 	WithPhase(phase apiv1.PodPhase) PodBuilder
+	WithContainerStatus(status *apiv1.ContainerStatus) PodBuilder
 	Get() *apiv1.Pod
 }
 
@@ -47,6 +48,7 @@ type podBuilderImpl struct {
 	labels            map[string]string
 	annotations       map[string]string
 	phase             apiv1.PodPhase
+	containerStatus   *apiv1.ContainerStatus
 }
 
 func (pb *podBuilderImpl) WithLabels(labels map[string]string) PodBuilder {
@@ -83,6 +85,12 @@ func (pb *podBuilderImpl) WithCreator(creatorObjectMeta *metav1.ObjectMeta, crea
 func (pb *podBuilderImpl) WithPhase(phase apiv1.PodPhase) PodBuilder {
 	r := *pb
 	r.phase = phase
+	return &r
+}
+
+func (pb *podBuilderImpl) WithContainerStatus(status *apiv1.ContainerStatus) PodBuilder {
+	r := *pb
+	r.containerStatus = status
 	return &r
 }
 
@@ -125,6 +133,10 @@ func (pb *podBuilderImpl) Get() *apiv1.Pod {
 	}
 	if pb.phase != "" {
 		pod.Status.Phase = pb.phase
+	}
+
+	if pb.containerStatus != nil {
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, *pb.containerStatus)
 	}
 
 	return pod

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -30,7 +30,7 @@ import (
 	vpa_types_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	vpa_lister_v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
-	"k8s.io/client-go/listers/core/v1"
+	v1lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -130,6 +130,12 @@ func (m *PodsEvictionRestrictionMock) Evict(pod *apiv1.Pod, eventRecorder record
 	return args.Error(0)
 }
 
+// EvictViaDelete is a mock implementation of PodsEvictionRestriction.EvictViaDelete
+func (m *PodsEvictionRestrictionMock) EvictViaDelete(pod *apiv1.Pod, eventRecorder record.EventRecorder, deletionThreshold int32) error {
+	args := m.Called(pod, eventRecorder, deletionThreshold)
+	return args.Error(0)
+}
+
 // CanEvict is a mock implementation of PodsEvictionRestriction.CanEvict
 func (m *PodsEvictionRestrictionMock) CanEvict(pod *apiv1.Pod) bool {
 	args := m.Called(pod)
@@ -142,11 +148,11 @@ type PodListerMock struct {
 }
 
 // Pods is a mock implementation of PodLister.Pods
-func (m *PodListerMock) Pods(namespace string) v1.PodNamespaceLister {
+func (m *PodListerMock) Pods(namespace string) v1lister.PodNamespaceLister {
 	args := m.Called(namespace)
-	var returnArg v1.PodNamespaceLister
+	var returnArg v1lister.PodNamespaceLister
 	if args.Get(0) != nil {
-		returnArg = args.Get(0).(v1.PodNamespaceLister)
+		returnArg = args.Get(0).(v1lister.PodNamespaceLister)
 	}
 	return returnArg
 }


### PR DESCRIPTION
#### Which component this PR applies to?

vertical-pod-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new experimental feature, which can be enabled via
a command line flag which attempts a pod deletion should the eviction
fail for whatever reason.
The deletion is bound to various conditions to not blindly delete a pod
where the eviction failure might be justified.
In general the deletion only occurs if at least one container was
OOMKilled and is currently in CrashLoopBackoff and the number of
restarts exceeeds the configured threshold (also behind a flag).

#### Which issue(s) this PR fixes:
Fixes #4730

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
New experimental feature to delete pods after eviction fails
```
